### PR TITLE
feat: add doctype to example HTML

### DIFF
--- a/public/goodbye.html
+++ b/public/goodbye.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 
   <head>

--- a/public/index.html
+++ b/public/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 
   <head>


### PR DESCRIPTION
The doctype is required at the top of HTML5 documents and without it browsers can make odd rendering decisions. It can be helpful to have this in case folks try to build simple HTML app prototypes off of it or they could end up with unexpected rendering problems.